### PR TITLE
remove multigsea 1.8.0

### DIFF
--- a/tool_list.yaml.lock
+++ b/tool_list.yaml.lock
@@ -2458,7 +2458,6 @@ tools:
 - name: multigsea
   owner: iuc
   revisions:
-  - 28e29a3d0eda
   - e48b10ce08b8
   tool_panel_section_label: Transcriptomics
 - name: emboss_5


### PR DESCRIPTION
- never had a container and therefore always has been dysfunctional 
- has been uninstalled manually