### PR TITLE
remove the roi import tool of lldelisle

### DIFF
--- a/tool_list.yaml
+++ b/tool_list.yaml
@@ -3147,9 +3147,6 @@ tools:
 - name: cp_cellprofiler
   owner: bgruening
   tool_panel_section_label: Imaging
-- name: upload_roi_and_measures_to_omero
-  owner: lldelisle
-  tool_panel_section_label: Imaging
 - name: rfove
   owner: imgteam
   tool_panel_section_label: Imaging


### PR DESCRIPTION
apparently this never worked, because there is no container

@rmassei can thi be removed or should I try to get a container for it?