### PR TITLE
Add xls2tabular to the tool list

### DIFF
--- a/tool_list.yaml
+++ b/tool_list.yaml
@@ -3200,3 +3200,9 @@ tools:
 - name: omero_get_value
   owner: ufz
   tool_panel_section_label: Imaging
+- name: split_file_on_column
+  owner: bgruening
+  tool_panel_section_label: Text Manipulation
+- name: xls2tabular
+  owner: ylebras
+  tool_panel_section_label: Convert Formats

--- a/tool_list.yaml
+++ b/tool_list.yaml
@@ -3200,9 +3200,6 @@ tools:
 - name: omero_get_value
   owner: ufz
   tool_panel_section_label: Imaging
-- name: split_file_on_column
-  owner: bgruening
-  tool_panel_section_label: Text Manipulation
 - name: xls2tabular
   owner: ylebras
   tool_panel_section_label: Convert Formats


### PR DESCRIPTION
Added two tools for:
1) Text manipulation (split tabular file into a collection of tabulars)
2) Convert xls sheet to a tabular


**Update** 
1) Text manipulation (split tabular file into a collection of tabulars) was added in https://github.com/Helmholtz-UFZ/ufz-galaxy-tools/pull/30