### PR TITLE
uninstall metams 1.22.1

### DIFF
--- a/tool_list.yaml.lock
+++ b/tool_list.yaml.lock
@@ -918,7 +918,6 @@ tools:
   - 93508ea69eb5
   - b8d4129dd2a6
   - c75532b75ba1
-  - d1ce2634135f
   tool_panel_section_label: Metabolomics - W4M
 - name: nmr_bucketing
   owner: marie-tremblay-metatoul


### PR DESCRIPTION
because there was never a version bioconductor-metams=1.22.1

- the conda environment used 1.24
- a container can not be constructed

hence users can use 3.0.0+metaMS1.24.0-galaxy0