### PR TITLE
remove lipidmaps_textsearch

### DIFF
--- a/tool_list.yaml
+++ b/tool_list.yaml
@@ -1691,9 +1691,10 @@ tools:
 - name: bank_inhouse
   owner: fgiacomoni
   tool_panel_section_label: Metabolomics - W4M
-- name: lipidmaps_textsearch
-  owner: fgiacomoni
-  tool_panel_section_label: Metabolomics - W4M
+# Old version 2018-10-02 broken and uninstalled, no new version available yet
+# - name: lipidmaps_textsearch
+#   owner: fgiacomoni
+#   tool_panel_section_label: Metabolomics - W4M
 - name: massbank_ws_searchspectrum
   owner: fgiacomoni
   tool_panel_section_label: Metabolomics - W4M

--- a/tool_list.yaml.lock
+++ b/tool_list.yaml.lock
@@ -4542,11 +4542,6 @@ tools:
   revisions:
   - 52798007c6b2
   tool_panel_section_label: Metabolomics - W4M
-- name: lipidmaps_textsearch
-  owner: fgiacomoni
-  revisions:
-  - f4e6b77c46e3
-  tool_panel_section_label: Metabolomics - W4M
 - name: massbank_ws_searchspectrum
   owner: fgiacomoni
   revisions:


### PR DESCRIPTION
toolshed.g2.bx.psu.edu/repos/fgiacomoni/lipidmaps_textsearch/lipidmaps/2018-10-02 was broken and uninstalled

no replacement yet