### PR TITLE
remove omero metadata import revision

### DIFF
--- a/tool_list.yaml.lock
+++ b/tool_list.yaml.lock
@@ -8236,7 +8236,6 @@ tools:
   - 352e9d4eaf70
   - 588d6fa22fc4
   - e41f70e69349
-  - eba4011643dd
   tool_panel_section_label: Imaging
 - name: omero_roi_import
   owner: ufz


### PR DESCRIPTION
tool revision was uninstallable

```
Error installing a repository (after 0:00:00.590216 seconds)! Name: omero_metadata_import,owner: ufz, revision: eba4011643dd, error: {"err_msg": "No information is available for the requested repository revision.\nOne or more of the following parameter values is likely invalid:\ntool_shed_url: https://toolshed.g2.bx.psu.edu/\nname: omero_metadata_import\nowner: ufz\nchangeset_revision: eba4011643dd\n", "err_code": 400008}
```

xref https://github.com/Helmholtz-UFZ/galaxy-tools/commit/54b50795912de3f2508cfcfc6911d71a94b34c56