### PR TITLE
remove ete 3.1.3

### DIFF
--- a/tool_list.yaml.lock
+++ b/tool_list.yaml.lock
@@ -1385,7 +1385,6 @@ tools:
   owner: earlhaminst
   revisions:
   - 16e925bf567e
-  - 1e85af7a29c4
   - 541a2ffc01ff
   - 6a5282f71f82
   - 87b6de3ef63e


### PR DESCRIPTION
never had a container (because 3.1.3+galax1 was pushed to fast :)