### PR TITLE
salmon dm: unintstall DM

### DIFF
--- a/tool_list.yaml.lock
+++ b/tool_list.yaml.lock
@@ -1249,12 +1249,6 @@ tools:
   - aec831b54a5b
   - f21e77139fb5
   tool_panel_section_label: Data Managers
-- name: data_manager_salmon_index_builder
-  owner: iuc
-  revisions:
-  - 566207ae614c
-  - 57274fe5e01a
-  tool_panel_section_label: Data Managers
 - name: data_manager_sam_fasta_index_builder
   owner: devteam
   revisions:


### PR DESCRIPTION
has never been used and would still require conda which is not supported anymore